### PR TITLE
docs: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 
 A custom element for extending the native media elements (`<audio>` or `<video>`).
 
+
 ## Usage
 
 ```js
@@ -41,6 +42,48 @@ export default MyCustomVideoElement;
 <my-custom-video
   src="https://stream.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/low.mp4"
 ></my-custom-video>
+```
+
+
+## Interfaces
+
+```ts
+export const Events: string[];
+
+export const template: HTMLTemplateElement;
+
+export class CustomAudioElement extends HTMLAudioElement implements HTMLAudioElement {
+  static readonly observedAttributes: string[];
+  static Events: string[];
+  static template: HTMLTemplateElement;
+  readonly nativeEl: HTMLAudioElement;
+  attributeChangedCallback(attrName: string, oldValue?: string | null, newValue?: string | null): void;
+  connectedCallback(): void;
+  disconnectedCallback(): void;
+}
+
+export class CustomVideoElement extends HTMLVideoElement implements HTMLVideoElement {
+  static readonly observedAttributes: string[];
+  static Events: string[];
+  static template: HTMLTemplateElement;
+  readonly nativeEl: HTMLVideoElement;
+  attributeChangedCallback(attrName: string, oldValue?: string | null, newValue?: string | null): void;
+  connectedCallback(): void;
+  disconnectedCallback(): void;
+}
+
+type CustomMediaElementConstructor<K> = {
+  readonly observedAttributes: string[];
+  Events: string[];
+  template: HTMLTemplateElement;
+  new(): K
+};
+
+export function CustomMediaMixin(Base: any, options: { tag: 'video', is: string }):
+  CustomMediaElementConstructor<CustomVideoElement>;
+
+export function CustomMediaMixin(Base: any, options: { tag: 'audio', is: string }):
+  CustomMediaElementConstructor<CustomAudioElement>;
 ```
 
 

--- a/custom-media-element.js
+++ b/custom-media-element.js
@@ -72,6 +72,7 @@ if (template) {
  */
 export const CustomMediaMixin = (superclass, { tag, is }) => {
 
+  // `is` makes it possible to extend a custom built-in. e.g. castable-video
   const nativeElTest = globalThis.document?.createElement(tag, { is });
   const nativeElProps = nativeElTest ? getNativeElProps(nativeElTest) : [];
 


### PR DESCRIPTION
Also wanted to put some notes here what changed from https://github.com/muxinc/custom-video-element because this is a new repo and we loose that code diff. 

The main fixes and differences are:

- the handling of attributes / properties is different than before in that it doesn't set properties by default in the attribute callback causing a potential endless loop if the override property was not gated e.g. if (this.loop == value) return.
  the observed attributes are limited to a static list that can be added on by the extending class.
- events can be attached before the custom media element is upgraded
- properties can be set before the custom media element is upgraded
- default template and Events list is overridable 