### PR TITLE
Watches native element controls attribute

### DIFF
--- a/custom-media-element.js
+++ b/custom-media-element.js
@@ -304,6 +304,13 @@ export const CustomMediaMixin = (superclass, { tag, is }) => {
           this.dispatchEvent(new CustomEvent(evt.type, { detail: evt.detail }));
         }, true);
       }
+
+      // Watch native controls attribute for change and update the custom element.
+      // A user can right click and choose to show and hide native controls
+      const observer = new MutationObserver(() => {
+        this.controls = this.nativeEl.controls;
+      });
+      observer.observe(this.nativeEl, { attributes: true, attributeFilter: ['controls'] });
     }
 
     #upgradeProperty(prop) {


### PR DESCRIPTION
This will observe the native controls attribute as it can be added and removed directly by the user through the right click context menu.

This change allows this css to hide the media chrome controls if native controls are visible

```css
media-controller [slot="media"][controls] ~ media-control-bar {
  display: none;
}
```