### PR TITLE
fix: enable default chapters & metadata track

### DIFF
--- a/custom-media-element.js
+++ b/custom-media-element.js
@@ -324,6 +324,21 @@ export const CustomMediaMixin = (superclass, { tag, is }) => {
             this.#childMap.set(el, clone);
           }
           this.nativeEl.append?.(clone);
+
+          // https://html.spec.whatwg.org/multipage/media.html#sourcing-out-of-band-text-tracks
+          // If there are any text tracks in the media element's list of text
+          // tracks whose text track kind is chapters or metadata that
+          // correspond to track elements with a default attribute set whose
+          // text track mode is set to disabled, then set the text track
+          // mode of all such tracks to hidden.
+          if (
+            clone.localName === 'track' &&
+            clone.default &&
+            (clone.kind === 'chapters' || clone.kind === 'metadata') &&
+            clone.track.mode === 'disabled'
+          ) {
+            clone.track.mode = 'hidden';
+          }
         });
 
       removeNativeChildren.forEach((el) => el.remove());


### PR DESCRIPTION
this fixes an issue where if the video track[default] children are cloned and appended to the native video element they would not be enabled by default because they're JS appended instead of HTML parsed on page load.

this might allow us to remove this code snippet in Mux elements but have to test to be sure.
https://github.com/muxinc/elements/blob/13bfbdbf474352f998417053285d82cbd3c730be/packages/playback-core/src/text-tracks.ts#L84-L108